### PR TITLE
Groups shard data via source_id

### DIFF
--- a/api/group_reader.proto
+++ b/api/group_reader.proto
@@ -52,10 +52,12 @@ message RemoveFromGroupResponse {
 
 message GroupReadRequest {
     string name = 1;
-    int64 start_time = 2;
-    int64 end_time = 3;
-    int64 limit = 4;
-    EnvelopeTypes envelope_type = 5;
+    uint64 requester_id = 2;
+
+    int64 start_time = 3;
+    int64 end_time = 4;
+    int64 limit = 5;
+    EnvelopeTypes envelope_type = 6;
 }
 
 message GroupReadResponse {
@@ -68,5 +70,6 @@ message GroupRequest {
 
 message GroupResponse {
     repeated string source_ids = 1;
+    repeated uint64 requester_ids = 2;
 }
 

--- a/group_reader.go
+++ b/group_reader.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"time"
 
 	"code.cloudfoundry.org/go-log-cache"
 	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache"
@@ -95,7 +96,8 @@ func (g *GroupReader) reverseProxy() rpc.GroupReaderServer {
 	var gs []rpc.GroupReaderClient
 	for i, a := range g.nodeAddrs {
 		if i == g.nodeIndex {
-			gs = append(gs, groups.NewManager(groups.NewStorage(1000, g.client.Read, g.metrics, g.log)))
+			s := groups.NewStorage(1000, g.client.Read, time.Second, g.metrics, g.log)
+			gs = append(gs, groups.NewManager(s, time.Minute))
 			continue
 		}
 

--- a/internal/groups/manager.go
+++ b/internal/groups/manager.go
@@ -14,9 +14,10 @@ import (
 
 // Manager manages groups. It implements logcache.GroupReader.
 type Manager struct {
-	mu sync.RWMutex
-	m  map[string][]string
-	s  DataStorage
+	mu               sync.RWMutex
+	m                map[string]groupInfo
+	s                DataStorage
+	requesterTimeout time.Duration
 }
 
 // DataStorage is used to store data for a given group.
@@ -29,20 +30,28 @@ type DataStorage interface {
 		end time.Time,
 		envelopeType store.EnvelopeType,
 		limit int,
+		requesterID uint64,
 	) []*loggregator_v2.Envelope
 
 	// Add starts fetching data for the given sourceID.
 	Add(name, sourceID string)
 
+	// AddRequester adds a requester ID for a given group.
+	AddRequester(name string, requesterID uint64)
+
 	// Remove stops fetching data for the given sourceID.
 	Remove(name, sourceID string)
+
+	// RemoveRequester removes a requester ID for a given group.
+	RemoveRequester(name string, requesterID uint64)
 }
 
 // NewManager creates a new Manager to manage groups.
-func NewManager(s DataStorage) *Manager {
+func NewManager(s DataStorage, requesterTimeout time.Duration) *Manager {
 	return &Manager{
-		m: make(map[string][]string),
-		s: s,
+		m:                make(map[string]groupInfo),
+		s:                s,
+		requesterTimeout: requesterTimeout,
 	}
 }
 
@@ -60,7 +69,13 @@ func (m *Manager) AddToGroup(ctx context.Context, r *logcache.AddToGroupRequest,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.m[r.Name] = append(m.m[r.Name], r.SourceId)
+	gi, ok := m.m[r.Name]
+	if !ok {
+		gi.requesterIDs = make(map[uint64]time.Time)
+	}
+
+	gi.sourceIDs = append(gi.sourceIDs, r.SourceId)
+	m.m[r.Name] = gi
 	m.s.Add(r.Name, r.SourceId)
 
 	return &logcache.AddToGroupResponse{}, nil
@@ -78,34 +93,59 @@ func (m *Manager) RemoveFromGroup(ctx context.Context, r *logcache.RemoveFromGro
 		return &logcache.RemoveFromGroupResponse{}, nil
 	}
 
-	for i, x := range a {
+	for i, x := range a.sourceIDs {
 		if x == r.SourceId {
-			m.m[r.Name] = append(a[:i], a[i+1:]...)
+			a.sourceIDs = append(a.sourceIDs[:i], a.sourceIDs[i+1:]...)
 			m.s.Remove(r.Name, r.SourceId)
 			break
 		}
 	}
+	m.m[r.Name] = a
 
-	if len(m.m[r.Name]) == 0 {
+	if len(m.m[r.Name].sourceIDs) == 0 {
 		delete(m.m, r.Name)
 	}
 	return &logcache.RemoveFromGroupResponse{}, nil
 }
 
 func (m *Manager) Read(ctx context.Context, r *logcache.GroupReadRequest, _ ...grpc.CallOption) (*logcache.GroupReadResponse, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	_, ok := m.m[r.Name]
+	gi, ok := m.m[r.Name]
 	if !ok {
 		return nil, grpc.Errorf(codes.NotFound, "unknown group name: %s", r.GetName())
+	}
+
+	if _, ok := gi.requesterIDs[r.RequesterId]; !ok {
+		m.s.AddRequester(r.Name, r.RequesterId)
+	}
+	gi.requesterIDs[r.RequesterId] = time.Now()
+
+	// Check for expired requesters
+	for k, v := range m.m[r.Name].requesterIDs {
+		if time.Since(v) >= m.requesterTimeout {
+			delete(m.m[r.Name].requesterIDs, k)
+			m.s.RemoveRequester(r.Name, k)
+		}
 	}
 
 	if r.GetEndTime() == 0 {
 		r.EndTime = time.Now().UnixNano()
 	}
 
-	batch := m.s.Get(r.GetName(), time.Unix(0, r.GetStartTime()), time.Unix(0, r.GetEndTime()), nil, 100)
+	if r.GetLimit() == 0 {
+		r.Limit = 100
+	}
+
+	batch := m.s.Get(
+		r.GetName(),
+		time.Unix(0, r.GetStartTime()),
+		time.Unix(0, r.GetEndTime()),
+		m.convertEnvelopeType(r.GetEnvelopeType()),
+		int(r.GetLimit()),
+		r.RequesterId,
+	)
 
 	return &logcache.GroupReadResponse{
 		Envelopes: &loggregator_v2.EnvelopeBatch{
@@ -120,7 +160,37 @@ func (m *Manager) Read(ctx context.Context, r *logcache.GroupReadRequest, _ ...g
 func (m *Manager) Group(ctx context.Context, r *logcache.GroupRequest, _ ...grpc.CallOption) (*logcache.GroupResponse, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	a := m.m[r.Name]
+
+	var reqIds []uint64
+	for k, _ := range a.requesterIDs {
+		reqIds = append(reqIds, k)
+	}
+
 	return &logcache.GroupResponse{
-		SourceIds: m.m[r.Name],
+		SourceIds:    a.sourceIDs,
+		RequesterIds: reqIds,
 	}, nil
+}
+
+func (m *Manager) convertEnvelopeType(t logcache.EnvelopeTypes) store.EnvelopeType {
+	switch t {
+	case logcache.EnvelopeTypes_LOG:
+		return &loggregator_v2.Log{}
+	case logcache.EnvelopeTypes_COUNTER:
+		return &loggregator_v2.Counter{}
+	case logcache.EnvelopeTypes_GAUGE:
+		return &loggregator_v2.Gauge{}
+	case logcache.EnvelopeTypes_TIMER:
+		return &loggregator_v2.Timer{}
+	case logcache.EnvelopeTypes_EVENT:
+		return &loggregator_v2.Event{}
+	default:
+		return nil
+	}
+}
+
+type groupInfo struct {
+	sourceIDs    []string
+	requesterIDs map[uint64]time.Time
 }

--- a/internal/groups/storage.go
+++ b/internal/groups/storage.go
@@ -2,11 +2,13 @@ package groups
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
 	gologcache "code.cloudfoundry.org/go-log-cache"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	orchestrator "code.cloudfoundry.org/go-orchestrator"
 	streamaggregator "code.cloudfoundry.org/go-stream-aggregator"
 	"code.cloudfoundry.org/log-cache/internal/store"
 )
@@ -14,14 +16,15 @@ import (
 // Storage stores data for groups. It prunes data out when the data is read.
 // It replenishes when the Replenish method is invoked.
 type Storage struct {
-	log *log.Logger
-	r   Reader
+	log     *log.Logger
+	r       Reader
+	backoff time.Duration
 
 	ctx    context.Context
 	cancel func()
 
 	// key=name
-	m map[string]aggregator
+	m map[string]*aggregator
 
 	streamAgg *streamaggregator.StreamAggregator
 	store     *store.Store
@@ -47,6 +50,7 @@ type Metrics interface {
 func NewStorage(
 	size int,
 	r Reader,
+	backoff time.Duration,
 	m Metrics,
 	log *log.Logger,
 ) *Storage {
@@ -54,11 +58,12 @@ func NewStorage(
 	s := &Storage{
 		log:       log,
 		r:         r,
+		backoff:   backoff,
 		streamAgg: streamaggregator.New(),
 		ctx:       ctx,
 		cancel:    cancel,
 		store:     store.NewStore(size, 1000, m),
-		m:         make(map[string]aggregator),
+		m:         make(map[string]*aggregator),
 	}
 
 	return s
@@ -72,42 +77,50 @@ func (s *Storage) Get(
 	end time.Time,
 	envelopeType store.EnvelopeType,
 	limit int,
+	requesterID uint64,
 ) []*loggregator_v2.Envelope {
-	return s.store.Get(name, start, end, envelopeType, limit)
+	encodedName := s.encodeName(name, requesterID)
+	return s.store.Get(encodedName, start, end, envelopeType, limit)
 }
 
 // Add adds a SourceID for the storage to fetch.
 func (s *Storage) Add(name, sourceID string) {
-	agg, ok := s.m[name]
-	if !ok {
-		ctx, cancel := context.WithCancel(context.Background())
-		agg = aggregator{
+	agg := s.initAggregator(name)
+
+	agg.sourceIDs = append(agg.sourceIDs, sourceID)
+
+	agg.orch.AddTask(sourceID)
+	agg.orch.NextTerm(context.Background())
+}
+
+// AddRequester adds a request ID for sharded reading.
+func (s *Storage) AddRequester(name string, ID uint64) {
+	agg := s.initAggregator(name)
+
+	if _, ok := agg.requesterIDs[ID]; !ok {
+		ctx, cancel := context.WithCancel(agg.ctx)
+		req := &requester{
 			agg:    streamaggregator.New(),
 			ctx:    ctx,
 			cancel: cancel,
 		}
-
-		go s.start(name, agg)
+		go s.start(s.encodeName(name, ID), req)
+		agg.requesterIDs[ID] = req
 	}
 
-	agg.sourceIDCount++
-	s.m[name] = agg
+	agg.orch.AddWorker(ID)
+	agg.orch.NextTerm(context.Background())
+}
 
-	agg.agg.AddProducer(sourceID, streamaggregator.ProducerFunc(func(ctx context.Context, request interface{}, c chan<- interface{}) {
-		gologcache.Walk(sourceID, func(e []*loggregator_v2.Envelope) bool {
-			for _, ee := range e {
-				select {
-				case c <- ee:
-				case <-ctx.Done():
-					return false
-				}
-			}
+// RemoveRequester removes a request ID for sharded reading.
+func (s *Storage) RemoveRequester(name string, ID uint64) {
+	agg := s.initAggregator(name)
 
-			return true
-		}, gologcache.Reader(s.r),
-			gologcache.WithWalkBackoff(gologcache.NewAlwaysRetryBackoff(time.Second)),
-		)
-	}))
+	agg.orch.RemoveWorker(ID)
+	agg.orch.NextTerm(context.Background())
+
+	agg.requesterIDs[ID].cancel()
+	delete(agg.requesterIDs, ID)
 }
 
 // Remove removes a SourceID from the store. The data will not be eagerly
@@ -118,42 +131,132 @@ func (s *Storage) Remove(name, sourceID string) {
 		return
 	}
 
-	agg.agg.RemoveProducer(sourceID)
+	agg.orch.RemoveTask(sourceID)
+	agg.orch.NextTerm(context.Background())
 
-	agg.sourceIDCount--
-	if agg.sourceIDCount == 0 {
+	for i, id := range agg.sourceIDs {
+		if id == sourceID {
+			agg.sourceIDs = append(agg.sourceIDs[:i], agg.sourceIDs[i+1:]...)
+		}
+	}
+
+	if len(agg.sourceIDs) == 0 {
+		agg.cancel()
 		delete(s.m, name)
 		return
 	}
-
-	s.m[name] = agg
 }
 
-func (s *Storage) start(name string, agg aggregator) {
-	for e := range agg.agg.Consume(agg.ctx, nil) {
-		s.store.Put(e.(*loggregator_v2.Envelope), name)
+func (s *Storage) initAggregator(name string) *aggregator {
+	agg, ok := s.m[name]
+	if !ok {
+		ctx, cancel := context.WithCancel(context.Background())
+		agg = &aggregator{
+			r:            s.r,
+			ctx:          ctx,
+			cancel:       cancel,
+			requesterIDs: make(map[uint64]*requester),
+			backoff:      s.backoff,
+		}
+
+		agg.orch = orchestrator.New(agg)
+
+		s.m[name] = agg
+	}
+
+	return agg
+}
+
+func (s *Storage) start(encodedName string, req *requester) {
+	for e := range req.agg.Consume(req.ctx, nil) {
+		s.store.Put(e.(*loggregator_v2.Envelope), encodedName)
 	}
 }
 
+func (s *Storage) encodeName(name string, requesterID uint64) string {
+	return fmt.Sprintf("%s-%d", name, requesterID)
+}
+
 type aggregator struct {
-	agg           *streamaggregator.StreamAggregator
-	sourceIDCount int
-	ctx           context.Context
-	cancel        func()
+	orch         *orchestrator.Orchestrator
+	r            Reader
+	sourceIDs    []string
+	requesterIDs map[uint64]*requester
+	backoff      time.Duration
+
+	ctx    context.Context
+	cancel func()
 }
 
-type envelopes []*loggregator_v2.Envelope
+type requester struct {
+	sourceIDs []string
+	agg       *streamaggregator.StreamAggregator
 
-func (i envelopes) Len() int {
-	return len(i)
+	ctx    context.Context
+	cancel func()
 }
 
-func (i envelopes) Less(a, b int) bool {
-	return i[a].GetTimestamp() < i[b].GetTimestamp()
+// List implements orchestrator.Communicator.
+func (a *aggregator) List(ctx context.Context, worker interface{}) ([]interface{}, error) {
+	y, ok := a.requesterIDs[worker.(uint64)]
+	if !ok {
+		return nil, nil
+	}
+
+	var r []interface{}
+	for _, x := range y.sourceIDs {
+		r = append(r, x)
+	}
+
+	return r, nil
 }
 
-func (i envelopes) Swap(a, b int) {
-	tmp := i[a]
-	i[a] = i[b]
-	i[b] = tmp
+// Add implements orchestrator.Communicator.
+func (a *aggregator) Add(ctx context.Context, worker interface{}, task interface{}) error {
+	id := worker.(uint64)
+	sourceID := task.(string)
+	req := a.requesterIDs[id]
+
+	// Ensure we aren't already doing this sourceID
+	for _, sid := range req.sourceIDs {
+		if sourceID == sid {
+			return nil
+		}
+	}
+
+	req.sourceIDs = append(req.sourceIDs, sourceID)
+
+	req.agg.AddProducer(sourceID, streamaggregator.ProducerFunc(func(ctx context.Context, request interface{}, c chan<- interface{}) {
+		gologcache.Walk(sourceID, func(e []*loggregator_v2.Envelope) bool {
+			for _, ee := range e {
+				select {
+				case c <- ee:
+				case <-ctx.Done():
+					return false
+				}
+			}
+
+			return true
+		}, gologcache.Reader(a.r),
+			gologcache.WithWalkBackoff(gologcache.NewAlwaysRetryBackoff(a.backoff)),
+		)
+	}))
+
+	return nil
+}
+
+// Remove implements orchestrator.Communicator.
+func (a *aggregator) Remove(ctx context.Context, worker interface{}, task interface{}) error {
+	id := worker.(uint64)
+	sourceID := task.(string)
+	req := a.requesterIDs[id]
+	for i, x := range req.sourceIDs {
+		if x == sourceID {
+			req.sourceIDs = append(req.sourceIDs[:i], req.sourceIDs[i+1:]...)
+		}
+	}
+
+	req.agg.RemoveProducer(sourceID)
+
+	return nil
 }


### PR DESCRIPTION
Each requester sets their requester_id to an unique
value. The group reader will then shard data to
each requester.