### PR TITLE
Update API definition

### DIFF
--- a/api/egress.proto
+++ b/api/egress.proto
@@ -24,7 +24,7 @@ message ReadRequest {
     int64 start_time = 2;
     int64 end_time = 3;
     int64 limit = 4;
-    EnvelopeTypes envelope_type = 5;
+    repeated EnvelopeTypes envelope_types = 5;
     bool descending = 6;
 }
 

--- a/api/group_reader.proto
+++ b/api/group_reader.proto
@@ -57,7 +57,7 @@ message GroupReadRequest {
     int64 start_time = 3;
     int64 end_time = 4;
     int64 limit = 5;
-    EnvelopeTypes envelope_type = 6;
+    repeated EnvelopeTypes envelope_types = 6;
 }
 
 message GroupReadResponse {


### PR DESCRIPTION
**DO NOT MERGE** Just looking for feedback.

Make envelope_types in requests an array rather than single value to support getting multiple types of envelopes in a single request.
