### PR TITLE
Spread groups out across 5 nodes

### DIFF
--- a/api/v1/group_reader.proto
+++ b/api/v1/group_reader.proto
@@ -37,6 +37,7 @@ service GroupReader {
 message AddToGroupRequest {
     string name = 1;
     string source_id = 2;
+    bool local_only = 3;
 }
 
 message AddToGroupResponse {
@@ -45,6 +46,7 @@ message AddToGroupResponse {
 message RemoveFromGroupRequest {
     string name = 1;
     string source_id = 2;
+    bool local_only = 3;
 }
 
 message RemoveFromGroupResponse {
@@ -58,6 +60,7 @@ message GroupReadRequest {
     int64 end_time = 4;
     int64 limit = 5;
     EnvelopeTypes envelope_type = 6;
+    bool local_only = 7;
 }
 
 message GroupReadResponse {
@@ -66,6 +69,7 @@ message GroupReadResponse {
 
 message GroupRequest {
     string name = 1;
+    bool local_only = 2;
 }
 
 message GroupResponse {

--- a/api/v1/orchestration.proto
+++ b/api/v1/orchestration.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package logcache.v1;
+
+service Orchestration {
+    rpc AddRange(AddRangeRequest) returns (AddRangeResponse) {}
+    rpc ListRanges(ListRangesRequest) returns (ListRangesResponse) {}
+    rpc SetRanges(SetRangesRequest) returns (SetRangesResponse) {}
+}
+
+message Range {
+    // start is the first hash within the given range. [start..end]
+    uint64 start = 1;
+
+    // end is the last hash within the given range. [start..end]
+    uint64 end = 2;
+
+    // term is the term that the range was applied to. The term is ever
+    // incrementing (managed by the scheduler algorithm). A range with a
+    // larger term is preferred.
+    uint64 term = 3;
+}
+
+message Ranges {
+    repeated Range ranges = 1;
+}
+
+message AddRangeRequest {
+    Range range = 1;
+}
+
+message AddRangeResponse {
+}
+
+message ListRangesRequest {
+}
+
+message ListRangesResponse {
+    repeated Range ranges = 1;
+}
+
+message SetRangesRequest {
+    // The key is the address of the Log Cache node.
+    map<string, Ranges> ranges = 1;
+}
+
+message SetRangesResponse {
+}

--- a/cmd/group-reader/.gitignore
+++ b/cmd/group-reader/.gitignore
@@ -1,1 +1,1 @@
-gateway
+group-reader

--- a/cmd/group-reader/main.go
+++ b/cmd/group-reader/main.go
@@ -27,11 +27,13 @@ func main() {
 
 	// GroupReader uses the slice to figure out its address. We want to bind
 	// to the given one.
+	extAddr := cfg.NodeAddrs[cfg.NodeIndex]
 	cfg.NodeAddrs[cfg.NodeIndex] = cfg.Addr
 
 	reader := logcache.NewGroupReader(cfg.LogCacheAddr, cfg.NodeAddrs, cfg.NodeIndex,
 		logcache.WithGroupReaderLogger(log.New(os.Stderr, "[GROUP-READER] ", log.LstdFlags)),
 		logcache.WithGroupReaderMetrics(metrics.New(expvar.NewMap("GroupReader"))),
+		logcache.WithGroupReaderExternalAddr(extAddr),
 		logcache.WithGroupReaderServerOpts(
 			grpc.Creds(cfg.LogCacheTLS.Credentials("log-cache")),
 		),

--- a/cmd/scheduler/.gitignore
+++ b/cmd/scheduler/.gitignore
@@ -1,0 +1,1 @@
+scheduler

--- a/cmd/scheduler/config.go
+++ b/cmd/scheduler/config.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"time"
+
+	envstruct "code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/log-cache/internal/tls"
+)
+
+// Config is the configuration for a Scheduler.
+type Config struct {
+	TLS        tls.TLS
+	HealthPort int `env:"HEALTH_PORT"`
+
+	Interval time.Duration `env:"INTERVAL"`
+	Count    int           `env:"COUNT"`
+
+	// NodeAddrs are all the LogCache addresses. They are in order according
+	// to their NodeIndex.
+	NodeAddrs []string `env:"NODE_ADDRS"`
+}
+
+// LoadConfig creates Config object from environment variables
+func LoadConfig() (*Config, error) {
+	c := Config{
+		HealthPort: 6064,
+		Count:      100,
+		Interval:   time.Minute,
+	}
+
+	if err := envstruct.Load(&c); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"expvar"
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
+	"code.cloudfoundry.org/go-envstruct"
+	logcache "code.cloudfoundry.org/log-cache"
+	"code.cloudfoundry.org/log-cache/internal/metrics"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	log.Print("Starting Log Cache Scheduler...")
+	defer log.Print("Closing Log Cache Scheduler.")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		log.Fatalf("invalid configuration: %s", err)
+	}
+
+	envstruct.WriteReport(cfg)
+
+	sched := logcache.NewScheduler(
+		cfg.NodeAddrs,
+		logcache.WithSchedulerLogger(log.New(os.Stderr, "", log.LstdFlags)),
+		logcache.WithSchedulerMetrics(metrics.New(expvar.NewMap("Scheduler"))),
+		logcache.WithSchedulerInterval(cfg.Interval),
+		logcache.WithSchedulerCount(cfg.Count),
+		logcache.WithSchedulerDialOpts(
+			grpc.WithTransportCredentials(cfg.TLS.Credentials("log-cache")),
+		),
+	)
+
+	sched.Start()
+
+	// health endpoints (pprof and expvar)
+	log.Printf("Health: %s", http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.HealthPort), nil))
+}

--- a/group_reader.go
+++ b/group_reader.go
@@ -19,6 +19,8 @@ import (
 // from many different source IDs much like it would read from one.
 type GroupReader struct {
 	addr    string
+	extAddr string
+
 	lis     net.Listener
 	log     *log.Logger
 	client  *logcache.Client
@@ -35,12 +37,17 @@ type GroupReader struct {
 // every node in the cluster (including its own). The nodeIndex is the address
 // of the current node.
 func NewGroupReader(logCacheAddr string, nodeAddrs []string, nodeIndex int, opts ...GroupReaderOption) *GroupReader {
-	r := &GroupReader{
-		addr:    nodeAddrs[nodeIndex],
-		log:     log.New(ioutil.Discard, "", 0),
-		metrics: nopMetrics{},
+	// Copy nodeAddrs to ensure we can manipulate without fear
+	na := make([]string, len(nodeAddrs))
+	copy(na, nodeAddrs)
 
-		nodeAddrs: nodeAddrs,
+	r := &GroupReader{
+		addr:     nodeAddrs[nodeIndex],
+		log:      log.New(ioutil.Discard, "", 0),
+		metrics:  nopMetrics{},
+		dialOpts: []grpc.DialOption{grpc.WithInsecure()},
+
+		nodeAddrs: na,
 		nodeIndex: nodeIndex,
 	}
 
@@ -56,8 +63,8 @@ func NewGroupReader(logCacheAddr string, nodeAddrs []string, nodeIndex int, opts
 // GroupReaderOption configures a GroupReader.
 type GroupReaderOption func(*GroupReader)
 
-// WithGroupReaderLogger returns a GroupReaderOption that configures the logger used for
-// the GroupReader. Defaults to silent logger.
+// WithGroupReaderLogger returns a GroupReaderOption that configures the
+// logger used for the GroupReader. Defaults to silent logger.
 func WithGroupReaderLogger(l *log.Logger) GroupReaderOption {
 	return func(r *GroupReader) {
 		r.log = l
@@ -88,6 +95,16 @@ func WithGroupReaderDialOpts(opts ...grpc.DialOption) GroupReaderOption {
 	}
 }
 
+// WithGroupReaderExternalAddr returns a GroupReaderOption that sets
+// address the scheduler will refer to the given node as. This is required
+// when the set address won't match what the scheduler will refer to the node
+// as (e.g. :0). Defaults to the resulting address from the listener.
+func WithGroupReaderExternalAddr(addr string) GroupReaderOption {
+	return func(g *GroupReader) {
+		g.extAddr = addr
+	}
+}
+
 // Start starts servicing for group requests. It does not block.
 func (g *GroupReader) Start() {
 	lis, err := net.Listen("tcp", g.addr)
@@ -96,13 +113,40 @@ func (g *GroupReader) Start() {
 	}
 	g.lis = lis
 
+	if g.extAddr == "" {
+		g.extAddr = lis.Addr().String()
+	}
+
+	// Ensure that everything that will receive the list of addresses, looks
+	// for the external address of this node and not the condensed address
+	// (e.g., :0).
+	g.nodeAddrs[g.nodeIndex] = g.extAddr
+
 	go func() {
-		s := grpc.NewServer(g.serverOpts...)
+		tableECMA := crc64.MakeTable(crc64.ECMA)
+		hasher := func(s string) uint64 {
+			return crc64.Checksum([]byte(s), tableECMA)
+		}
 
-		rp := g.reverseProxy()
+		p := store.NewPruneConsultant(2, 70, NewMemoryAnalyzer(g.metrics))
+		s := groups.NewStorage(g.client.Read, time.Second, p, g.metrics, g.log)
 
-		rpc.RegisterGroupReaderServer(s, rp)
-		if err := s.Serve(lis); err != nil {
+		m := groups.NewManager(s, time.Minute)
+		lookup := routing.NewRoutingTable(g.nodeAddrs, hasher)
+		orch := routing.NewOrchestrator(
+			g.extAddr,
+			hasher,
+			routing.MetaFetcherFunc(func() []string { return nil }),
+			lookup,
+		)
+
+		srv := grpc.NewServer(g.serverOpts...)
+
+		rp := g.reverseProxy(lookup, m)
+
+		rpc.RegisterGroupReaderServer(srv, rp)
+		rpc.RegisterOrchestrationServer(srv, orch)
+		if err := srv.Serve(lis); err != nil {
 			g.log.Fatalf("failed to serve: %v", err)
 		}
 	}()
@@ -113,13 +157,11 @@ func (g *GroupReader) Addr() string {
 	return g.lis.Addr().String()
 }
 
-func (g *GroupReader) reverseProxy() rpc.GroupReaderServer {
-	p := store.NewPruneConsultant(2, 70, NewMemoryAnalyzer(g.metrics))
+func (g *GroupReader) reverseProxy(lookup groups.Lookup, m *groups.Manager) rpc.GroupReaderServer {
 	var gs []rpc.GroupReaderClient
 	for i, a := range g.nodeAddrs {
 		if i == g.nodeIndex {
-			s := groups.NewStorage(g.client.Read, time.Second, p, g.metrics, g.log)
-			gs = append(gs, groups.NewManager(s, time.Minute))
+			gs = append(gs, m)
 			continue
 		}
 
@@ -129,13 +171,6 @@ func (g *GroupReader) reverseProxy() rpc.GroupReaderServer {
 		}
 		gs = append(gs, rpc.NewGroupReaderClient(conn))
 	}
-
-	tableECMA := crc64.MakeTable(crc64.ECMA)
-	hasher := func(s string) uint64 {
-		return crc64.Checksum([]byte(s), tableECMA)
-	}
-
-	lookup := routing.NewStaticLookup(len(g.nodeAddrs), hasher)
 
 	return groups.NewRPCReverseProxy(gs, lookup, g.log)
 }

--- a/group_reader.go
+++ b/group_reader.go
@@ -172,5 +172,5 @@ func (g *GroupReader) reverseProxy(lookup groups.Lookup, m *groups.Manager) rpc.
 		gs = append(gs, rpc.NewGroupReaderClient(conn))
 	}
 
-	return groups.NewRPCReverseProxy(gs, lookup, g.log)
+	return groups.NewRPCReverseProxy(gs, g.nodeIndex, lookup, g.log)
 }

--- a/internal/end2end/end2end_suite_test.go
+++ b/internal/end2end/end2end_suite_test.go
@@ -1,0 +1,13 @@
+package end2end_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestEnd2end(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "End2end Suite")
+}

--- a/internal/end2end/group_reader_test.go
+++ b/internal/end2end/group_reader_test.go
@@ -1,0 +1,198 @@
+package end2end_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	gologcache "code.cloudfoundry.org/go-log-cache"
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	logcache "code.cloudfoundry.org/log-cache"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("GroupReader", func() {
+	var (
+		// Run is incremented for each spec. It is used to set the port
+		// numbers.
+		run      int
+		addrs    []string
+		logCache *logcache.LogCache
+
+		node1     *logcache.GroupReader
+		node2     *logcache.GroupReader
+		scheduler *logcache.Scheduler
+
+		client1  *gologcache.GroupReaderClient
+		client2  *gologcache.GroupReaderClient
+		lcClient *gologcache.Client
+	)
+
+	BeforeEach(func() {
+		run++
+		addrs = []string{
+			fmt.Sprintf("127.0.0.1:%d", 9999+(run*2)),
+			fmt.Sprintf("127.0.0.1:%d", 10000+(run*2)),
+		}
+
+		logCache = logcache.New(
+			logcache.WithAddr("127.0.0.1:0"),
+		)
+		logCache.Start()
+
+		addr := logCache.Addr()
+
+		node1 = logcache.NewGroupReader(addr, addrs, 0)
+		node2 = logcache.NewGroupReader(addr, addrs, 1)
+
+		scheduler = logcache.NewScheduler(
+			addrs,
+			logcache.WithSchedulerInterval(time.Millisecond),
+		)
+
+		node1.Start()
+		node2.Start()
+		scheduler.Start()
+
+		lcClient = gologcache.NewClient(addr, gologcache.WithViaGRPC(grpc.WithInsecure()))
+		client1 = gologcache.NewGroupReaderClient(addrs[0], gologcache.WithViaGRPC(grpc.WithInsecure()))
+		client2 = gologcache.NewGroupReaderClient(addrs[1], gologcache.WithViaGRPC(grpc.WithInsecure()))
+	})
+
+	It("keeps track of groups", func() {
+		go func(client1, client2 *gologcache.GroupReaderClient) {
+			for range time.Tick(time.Millisecond) {
+				client1.AddToGroup(context.Background(), "some-name", "a")
+				client2.AddToGroup(context.Background(), "some-name", "b")
+			}
+		}(client1, client2)
+
+		Eventually(func() []string {
+			m, err := client1.Group(context.Background(), "some-name")
+			if err != nil {
+				return nil
+			}
+
+			return m.SourceIDs
+		}, 5).Should(ConsistOf("a", "b"))
+	})
+
+	It("reads from several source IDs", func() {
+		go func(client1, client2 *gologcache.GroupReaderClient) {
+			for range time.Tick(time.Millisecond) {
+				client1.AddToGroup(context.Background(), "some-name", "a")
+				client2.AddToGroup(context.Background(), "some-name", "b")
+			}
+		}(client1, client2)
+
+		_, err := ingressClient(logCache.Addr()).Send(context.Background(), &rpc.SendRequest{
+			Envelopes: &loggregator_v2.EnvelopeBatch{
+				Batch: []*loggregator_v2.Envelope{
+					{SourceId: "a", Timestamp: 1},
+					{SourceId: "a", Timestamp: 2},
+					{SourceId: "b", Timestamp: 3},
+					{SourceId: "b", Timestamp: 4},
+					{SourceId: "c", Timestamp: 5},
+				},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() []int {
+			envelopes, err := client1.Read(
+				context.Background(),
+				"some-name",
+				time.Unix(0, 0),
+				0,
+			)
+			if err != nil {
+				return nil
+			}
+
+			var results []int
+			for _, e := range envelopes {
+				results = append(results, int(e.GetTimestamp()))
+			}
+			return results
+		}, 5).Should(ConsistOf(1, 2, 3, 4))
+	})
+
+	It("shards data via requester_id", func() {
+		go func(client1, client2 *gologcache.GroupReaderClient) {
+			for range time.Tick(time.Millisecond) {
+				client1.AddToGroup(context.Background(), "some-name", "a")
+				client2.AddToGroup(context.Background(), "some-name", "b")
+			}
+		}(client1, client2)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var once sync.Once
+
+		go func(addr string) {
+			defer GinkgoRecover()
+
+			wg.Wait()
+			_, err := ingressClient(addr).Send(context.Background(), &rpc.SendRequest{
+				Envelopes: &loggregator_v2.EnvelopeBatch{
+					Batch: []*loggregator_v2.Envelope{
+						{SourceId: "a", Timestamp: 1},
+						{SourceId: "a", Timestamp: 2},
+						{SourceId: "b", Timestamp: 3},
+						{SourceId: "b", Timestamp: 4},
+						{SourceId: "c", Timestamp: 5},
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		}(logCache.Addr())
+
+		Eventually(func() []int {
+			envelopes, err := client1.Read(
+				context.Background(),
+				"some-name",
+				time.Unix(0, 0),
+				0,
+			)
+			if err != nil {
+				return nil
+			}
+
+			var results []int
+			for _, e := range envelopes {
+				results = append(results, int(e.GetTimestamp()))
+			}
+
+			envelopes, err = client2.Read(
+				context.Background(),
+				"some-name",
+				time.Unix(0, 0),
+				1,
+			)
+			if err != nil {
+				return nil
+			}
+
+			for _, e := range envelopes {
+				results = append(results, int(e.GetTimestamp()))
+			}
+
+			once.Do(wg.Done)
+
+			return results
+		}, 5).Should(ConsistOf(1, 2, 3, 4))
+	})
+})
+
+func ingressClient(addr string) rpc.IngressClient {
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		panic(err)
+	}
+
+	return rpc.NewIngressClient(conn)
+}

--- a/internal/groups/manager.go
+++ b/internal/groups/manager.go
@@ -196,6 +196,19 @@ func (m *Manager) Group(ctx context.Context, r *logcache_v1.GroupRequest, _ ...g
 	}, nil
 }
 
+// ListGroups returns all the group names.
+func (m *Manager) ListGroups() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var results []string
+	for name := range m.m {
+		results = append(results, name)
+	}
+
+	return results
+}
+
 func (m *Manager) resetExpire(t *time.Timer) {
 	if !t.Stop() && len(t.C) != 0 {
 		<-t.C

--- a/internal/groups/manager_test.go
+++ b/internal/groups/manager_test.go
@@ -87,6 +87,8 @@ var _ = Describe("Manager", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rr).ToNot(BeNil())
+
+		Expect(m.ListGroups()).To(ConsistOf("b"))
 	})
 
 	It("keeps track of requester IDs for a group", func() {
@@ -302,7 +304,7 @@ var _ = Describe("Manager", func() {
 		var wg sync.WaitGroup
 		defer wg.Wait()
 
-		wg.Add(2)
+		wg.Add(3)
 		go func(m *groups.Manager) {
 			defer wg.Done()
 			for i := 0; i < 100; i++ {
@@ -319,6 +321,13 @@ var _ = Describe("Manager", func() {
 				m.Read(context.Background(), &logcache_v1.GroupReadRequest{
 					Name: "a",
 				})
+			}
+		}(m)
+
+		go func(m *groups.Manager) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				m.ListGroups()
 			}
 		}(m)
 

--- a/internal/groups/rpc_reverse_proxy.go
+++ b/internal/groups/rpc_reverse_proxy.go
@@ -2,7 +2,10 @@ package groups
 
 import (
 	"context"
+	"errors"
 	"log"
+	"math/rand"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
@@ -15,65 +18,171 @@ import (
 // it will  find the correct node and based on the type, it will make the
 // correct method call.
 type RPCReverseProxy struct {
-	log *log.Logger
-	l   Lookup
-	s   []logcache_v1.GroupReaderClient
+	log   *log.Logger
+	l     Lookup
+	s     []logcache_v1.GroupReaderClient
+	local int
 }
 
-// Lookup is used to find the correct node.
+// Lookup is used to find the correct nodes.
 type Lookup interface {
-	Lookup(name string) int
+	Lookup(name string) []int
 }
 
 // NewRequestRouter creates a new RPCReverseProxy.
-func NewRPCReverseProxy(s []logcache_v1.GroupReaderClient, l Lookup, log *log.Logger) *RPCReverseProxy {
+func NewRPCReverseProxy(s []logcache_v1.GroupReaderClient, local int, l Lookup, log *log.Logger) *RPCReverseProxy {
 	return &RPCReverseProxy{
-		s:   s,
-		l:   l,
-		log: log,
+		s:     s,
+		l:     l,
+		local: local,
+		log:   log,
 	}
 }
 
 // AddToGroup implements logcache_v1.GroupReaderServer.
 func (r *RPCReverseProxy) AddToGroup(c context.Context, req *logcache_v1.AddToGroupRequest) (*logcache_v1.AddToGroupResponse, error) {
-	idx := r.l.Lookup(req.GetName())
-	if idx < 0 {
+	nodes := r.l.Lookup(req.GetName())
+	if len(nodes) == 0 {
 		return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
 	}
 	c, _ = context.WithTimeout(c, 3*time.Second)
 
-	return r.s[idx].AddToGroup(c, req)
+	if req.LocalOnly {
+		if !r.contains(r.local, nodes) {
+			return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
+		}
+
+		return r.s[r.local].AddToGroup(c, req)
+	}
+
+	req.LocalOnly = true
+	errs := make(chan error, len(nodes))
+	for _, n := range nodes {
+		go func(n int) {
+			_, err := r.s[n].AddToGroup(c, req)
+			errs <- err
+		}(n)
+	}
+
+	var e []string
+	for i := 0; i < len(nodes); i++ {
+		err := <-errs
+		if err == nil {
+			// If even one succeeds, then we will say it worked out.
+			return &logcache_v1.AddToGroupResponse{}, nil
+		}
+		e = append(e, err.Error())
+	}
+
+	return nil, errors.New(strings.Join(e, ", "))
 }
 
 // RemoveFromGroup implements logcache_v1.GroupReaderServer.
 func (r *RPCReverseProxy) RemoveFromGroup(c context.Context, req *logcache_v1.RemoveFromGroupRequest) (*logcache_v1.RemoveFromGroupResponse, error) {
-	idx := r.l.Lookup(req.GetName())
-	if idx < 0 {
+	nodes := r.l.Lookup(req.GetName())
+	if len(nodes) == 0 {
 		return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
 	}
 	c, _ = context.WithTimeout(c, 3*time.Second)
 
-	return r.s[idx].RemoveFromGroup(c, req)
+	if req.LocalOnly {
+		if !r.contains(r.local, nodes) {
+			return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
+		}
+
+		return r.s[r.local].RemoveFromGroup(c, req)
+	}
+
+	req.LocalOnly = true
+	errs := make(chan error, len(nodes))
+	for _, n := range nodes {
+		go func(n int) {
+			_, err := r.s[n].RemoveFromGroup(c, req)
+			errs <- err
+		}(n)
+	}
+
+	var e []string
+	for i := 0; i < len(nodes); i++ {
+		err := <-errs
+		if err == nil {
+			// If even one succeeds, then we will say it worked out.
+			return &logcache_v1.RemoveFromGroupResponse{}, nil
+		}
+		e = append(e, err.Error())
+	}
+
+	return nil, errors.New(strings.Join(e, ", "))
 }
 
 // Read implements logcache_v1.GroupReaderServer.
 func (r *RPCReverseProxy) Read(c context.Context, req *logcache_v1.GroupReadRequest) (*logcache_v1.GroupReadResponse, error) {
-	idx := r.l.Lookup(req.GetName())
-	if idx < 0 {
+	nodes := r.l.Lookup(req.GetName())
+	if len(nodes) == 0 {
 		return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
 	}
 	c, _ = context.WithTimeout(c, 3*time.Second)
 
-	return r.s[idx].Read(c, req)
+	if req.LocalOnly {
+		if !r.contains(r.local, nodes) {
+			return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
+		}
+
+		return r.s[r.local].Read(c, req)
+	}
+
+	// We want each node to know about all the requester IDs for sharding.
+	ping := &logcache_v1.GroupReadRequest{
+		Name:        req.GetName(),
+		RequesterId: req.GetRequesterId(),
+		Limit:       -1,
+		LocalOnly:   true,
+	}
+
+	var (
+		resp *logcache_v1.GroupReadResponse
+		err  error
+	)
+
+	req.LocalOnly = true
+	for i, n := range nodes {
+		if i != int(req.GetRequesterId())%len(nodes) {
+			r.s[n].Read(c, ping)
+			continue
+		}
+
+		resp, err = r.s[n].Read(c, req)
+	}
+
+	return resp, err
 }
 
 // Group implements logcache_v1.GroupReaderServer.
 func (r *RPCReverseProxy) Group(c context.Context, req *logcache_v1.GroupRequest) (*logcache_v1.GroupResponse, error) {
-	idx := r.l.Lookup(req.GetName())
-	if idx < 0 {
+	nodes := r.l.Lookup(req.GetName())
+	if len(nodes) == 0 {
 		return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
 	}
 	c, _ = context.WithTimeout(c, 3*time.Second)
 
-	return r.s[idx].Group(c, req)
+	if req.LocalOnly {
+		if !r.contains(r.local, nodes) {
+			return nil, grpc.Errorf(codes.Unavailable, "unable to route request. Try again...")
+		}
+
+		return r.s[r.local].Group(c, req)
+	}
+
+	req.LocalOnly = true
+	n := nodes[rand.Intn(len(nodes))]
+	return r.s[n].Group(c, req)
+}
+
+func (r *RPCReverseProxy) contains(a int, b []int) bool {
+	for _, x := range b {
+		if x == a {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/groups/rpc_reverse_proxy_test.go
+++ b/internal/groups/rpc_reverse_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"sync"
 
 	"code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
 	"code.cloudfoundry.org/log-cache/internal/groups"
@@ -17,143 +18,249 @@ import (
 var _ = Describe("RPCReverseProxy", func() {
 	var (
 		r  *groups.RPCReverseProxy
+		s0 *spyGroupReaderClient
 		s1 *spyGroupReaderClient
 		s2 *spyGroupReaderClient
 		l  *spyLookup
 	)
 
 	BeforeEach(func() {
+		s0 = newSpyGroupReaderClient()
 		s1 = newSpyGroupReaderClient()
 		s2 = newSpyGroupReaderClient()
 		l = newSpyLookup()
 		r = groups.NewRPCReverseProxy(
-			[]logcache_v1.GroupReaderClient{s1, s2},
+			[]logcache_v1.GroupReaderClient{s0, s1, s2},
+			0,
 			l,
 			log.New(GinkgoWriter, "", 0),
 		)
 	})
 
 	It("proxies AddToGroupRequests to the correct nodes", func() {
-		l.result = 0
+		l.results = []int{0, 2}
 		req := &logcache_v1.AddToGroupRequest{
 			Name: "some-name-0",
 		}
-		s1.addErr = errors.New("some-err")
+		s0.addErr = errors.New("some-err")
+		s2.addErr = errors.New("some-err")
 		_, err := r.AddToGroup(context.Background(), req)
-		Expect(s1.addToGroupRequests).To(ConsistOf(req))
-		Expect(err).To(MatchError("some-err"))
-
-		l.result = 1
-		_, err = r.AddToGroup(context.Background(), req)
+		Expect(err).To(MatchError("some-err, some-err"))
+		Expect(s0.addToGroupRequests).To(ConsistOf(req))
 		Expect(s2.addToGroupRequests).To(ConsistOf(req))
+
+		l.results = []int{1, 2}
+		req.LocalOnly = false
+		_, err = r.AddToGroup(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(s1.addToGroupRequests).To(ConsistOf(req))
 		Expect(l.names).To(ConsistOf("some-name-0", "some-name-0"))
 	})
 
+	It("proxies local AddToGroupRequests to the the local node", func() {
+		req := &logcache_v1.AddToGroupRequest{
+			Name:      "some-name-0",
+			LocalOnly: true,
+		}
+
+		l.results = []int{0, 2}
+
+		_, err := r.AddToGroup(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(s0.AddToGroupRequests()).To(ConsistOf(req))
+		Expect(s2.AddToGroupRequests()).To(BeEmpty())
+	})
+
 	It("AddToGroupRequests returns Unavailable when request is unroutable", func() {
-		l.result = -1
 		req := &logcache_v1.AddToGroupRequest{
 			Name: "some-name-0",
 		}
 		_, err := r.AddToGroup(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+
+		l.results = []int{1, 2}
+		req.LocalOnly = true
+		_, err = r.AddToGroup(context.Background(), req)
 		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 
 	It("proxies RemoveFromGroupRequests to the correct nodes", func() {
-		l.result = 0
+		l.results = []int{0, 2}
 		req := &logcache_v1.RemoveFromGroupRequest{
 			Name: "some-name-0",
 		}
-		s1.removeErr = errors.New("some-err")
+		s0.removeErr = errors.New("some-err")
+		s2.removeErr = errors.New("some-err")
 		_, err := r.RemoveFromGroup(context.Background(), req)
-		Expect(s1.removeFromGroupRequests).To(ConsistOf(req))
-		Expect(err).To(MatchError("some-err"))
-
-		l.result = 1
-		_, err = r.RemoveFromGroup(context.Background(), req)
+		Expect(err).To(MatchError("some-err, some-err"))
+		req.LocalOnly = true
+		Expect(s0.removeFromGroupRequests).To(ConsistOf(req))
 		Expect(s2.removeFromGroupRequests).To(ConsistOf(req))
+	})
+
+	It("proxies local RemoveFromGroupRequests to the local node", func() {
+		req := &logcache_v1.RemoveFromGroupRequest{
+			Name:      "some-name-0",
+			LocalOnly: true,
+		}
+		l.results = []int{0, 2}
+		_, err := r.RemoveFromGroup(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(s0.RemoveFromGroupRequests()).To(ConsistOf(req))
+		Expect(s2.RemoveFromGroupRequests()).To(BeEmpty())
 	})
 
 	It("RemoveFromGroupRequests returns Unavailable when request is unroutable", func() {
-		l.result = -1
 		req := &logcache_v1.RemoveFromGroupRequest{
 			Name: "some-name-0",
 		}
 		_, err := r.RemoveFromGroup(context.Background(), req)
 		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+
+		l.results = []int{1, 2}
+		req.LocalOnly = true
+		_, err = r.RemoveFromGroup(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 
-	It("proxies ReadRequests to the correct nodes", func() {
-		l.result = 0
+	It("proxies ReadRequests to the correct node based on requester ID", func() {
+		l.results = []int{0, 2}
 		req := &logcache_v1.GroupReadRequest{
-			Name: "some-name-0",
+			Name:        "some-name-0",
+			RequesterId: 1,
 		}
-		s1.readErr = errors.New("some-err")
+		s2.readErr = errors.New("some-err")
 		_, err := r.Read(context.Background(), req)
-		Expect(s1.groupReadRequests).To(ConsistOf(req))
 		Expect(err).To(MatchError("some-err"))
 
-		l.result = 1
-		_, err = r.Read(context.Background(), req)
+		// This is more of a 'ping' message to other nodes so they know to
+		// shard their data.
+		Expect(s0.groupReadRequests).To(ConsistOf(&logcache_v1.GroupReadRequest{
+			Name:        "some-name-0",
+			RequesterId: 1,
+			Limit:       -1,
+			LocalOnly:   true,
+		}))
+		req.LocalOnly = true
 		Expect(s2.groupReadRequests).To(ConsistOf(req))
+
+		l.results = []int{0, 1}
+		req.LocalOnly = false
+		_, err = r.Read(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(s1.groupReadRequests).To(ConsistOf(req))
+		Expect(l.names).To(ConsistOf("some-name-0", "some-name-0"))
+
+		l.results = []int{0, 2}
+		s0.readErr = nil
+		req.LocalOnly = true
+		s0.groupReadRequests = nil
+		s2.groupReadRequests = nil
+		_, err = r.Read(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(s0.groupReadRequests).To(ConsistOf(req))
+		Expect(s2.groupReadRequests).To(BeEmpty())
 	})
 
 	It("Read returns Unavailable when request is unroutable", func() {
-		l.result = -1
 		req := &logcache_v1.GroupReadRequest{
 			Name: "some-name-0",
 		}
 		_, err := r.Read(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+
+		l.results = []int{1, 2}
+		req.LocalOnly = true
+		_, err = r.Read(context.Background(), req)
 		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 
 	It("proxies GroupRequests to the correct nodes", func() {
-		l.result = 0
+		l.results = []int{0, 1}
 		req := &logcache_v1.GroupRequest{
 			Name: "some-name-0",
 		}
+		s0.groupErr = errors.New("some-err")
 		s1.groupErr = errors.New("some-err")
 		_, err := r.Group(context.Background(), req)
-		Expect(s1.groupRequests).To(ConsistOf(req))
+		req.LocalOnly = true
+		Expect(append(s0.groupRequests, s1.groupRequests...)).To(ConsistOf(req))
 		Expect(err).To(MatchError("some-err"))
 
-		l.result = 1
-		_, err = r.Group(context.Background(), req)
-		Expect(s2.groupRequests).To(ConsistOf(req))
+		l.results = []int{0, 1}
+		s0.groupErr = nil
+		s1.groupErr = nil
+		req.LocalOnly = false
+		s0.groupRespSourceIDs = []string{"a", "b"}
+		s1.groupRespSourceIDs = []string{"b", "c"}
+		s0.groupRespRequesterIDs = []uint64{99, 100}
+		s1.groupRespRequesterIDs = []uint64{100, 101}
+
+		resp, err := r.Group(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Its eventually consistent, and just picks one to query
+		Expect(resp.SourceIds).To(
+			Or(
+				ConsistOf("a", "b"),
+				ConsistOf("b", "c"),
+			),
+		)
+		Expect(resp.RequesterIds).To(
+			Or(
+				ConsistOf(uint64(99), uint64(100)),
+				ConsistOf(uint64(100), uint64(101)),
+			),
+		)
+
+		l.results = []int{0, 2}
+		s0.groupErr = nil
+		req.LocalOnly = true
+		s0.groupRequests = nil
+		s2.groupRequests = nil
+		_, err = r.Group(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(s0.groupRequests).To(ConsistOf(req))
+		Expect(s2.groupRequests).To(BeEmpty())
 	})
 
 	It("Group returns Unavailable when request is unroutable", func() {
-		l.result = -1
 		req := &logcache_v1.GroupRequest{
 			Name: "some-name-0",
 		}
 		_, err := r.Group(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+
+		l.results = []int{1, 2}
+		req.LocalOnly = true
+		_, err = r.Group(context.Background(), req)
 		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 })
 
 type spyLookup struct {
-	names  []string
-	result int
+	names   []string
+	results []int
 }
 
 func newSpyLookup() *spyLookup {
 	return &spyLookup{}
 }
 
-func (s *spyLookup) Lookup(name string) int {
+func (s *spyLookup) Lookup(name string) []int {
 	s.names = append(s.names, name)
-	return s.result
+	return s.results
 }
 
 type spyGroupReaderClient struct {
+	mu                      sync.Mutex
 	addToGroupRequests      []*logcache_v1.AddToGroupRequest
 	removeFromGroupRequests []*logcache_v1.RemoveFromGroupRequest
 	groupReadRequests       []*logcache_v1.GroupReadRequest
 	groupRequests           []*logcache_v1.GroupRequest
+
+	groupRespSourceIDs    []string
+	groupRespRequesterIDs []uint64
 
 	addErr    error
 	removeErr error
@@ -166,21 +273,64 @@ func newSpyGroupReaderClient() *spyGroupReaderClient {
 }
 
 func (s *spyGroupReaderClient) AddToGroup(c context.Context, r *logcache_v1.AddToGroupRequest, _ ...grpc.CallOption) (*logcache_v1.AddToGroupResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.addToGroupRequests = append(s.addToGroupRequests, r)
 	return &logcache_v1.AddToGroupResponse{}, s.addErr
 }
 
+func (s *spyGroupReaderClient) setAddToGroup(r []*logcache_v1.AddToGroupRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addToGroupRequests = r
+}
+
+func (s *spyGroupReaderClient) AddToGroupRequests() []*logcache_v1.AddToGroupRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r := make([]*logcache_v1.AddToGroupRequest, len(s.addToGroupRequests))
+	copy(r, s.addToGroupRequests)
+
+	return r
+}
+
 func (s *spyGroupReaderClient) RemoveFromGroup(c context.Context, r *logcache_v1.RemoveFromGroupRequest, _ ...grpc.CallOption) (*logcache_v1.RemoveFromGroupResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.removeFromGroupRequests = append(s.removeFromGroupRequests, r)
 	return &logcache_v1.RemoveFromGroupResponse{}, s.removeErr
 }
 
+func (s *spyGroupReaderClient) setRemoveFromGroup(r []*logcache_v1.RemoveFromGroupRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeFromGroupRequests = r
+}
+
+func (s *spyGroupReaderClient) RemoveFromGroupRequests() []*logcache_v1.RemoveFromGroupRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r := make([]*logcache_v1.RemoveFromGroupRequest, len(s.removeFromGroupRequests))
+	copy(r, s.removeFromGroupRequests)
+
+	return r
+}
+
 func (s *spyGroupReaderClient) Read(c context.Context, r *logcache_v1.GroupReadRequest, _ ...grpc.CallOption) (*logcache_v1.GroupReadResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.groupReadRequests = append(s.groupReadRequests, r)
 	return &logcache_v1.GroupReadResponse{}, s.readErr
 }
 
 func (s *spyGroupReaderClient) Group(c context.Context, r *logcache_v1.GroupRequest, _ ...grpc.CallOption) (*logcache_v1.GroupResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.groupRequests = append(s.groupRequests, r)
-	return &logcache_v1.GroupResponse{}, s.groupErr
+	return &logcache_v1.GroupResponse{
+		SourceIds:    s.groupRespSourceIDs,
+		RequesterIds: s.groupRespRequesterIDs,
+	}, s.groupErr
 }

--- a/internal/groups/rpc_reverse_proxy_test.go
+++ b/internal/groups/rpc_reverse_proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
 	"code.cloudfoundry.org/log-cache/internal/groups"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,6 +47,16 @@ var _ = Describe("RPCReverseProxy", func() {
 		_, err = r.AddToGroup(context.Background(), req)
 		Expect(s2.addToGroupRequests).To(ConsistOf(req))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(l.names).To(ConsistOf("some-name-0", "some-name-0"))
+	})
+
+	It("AddToGroupRequests returns Unavailable when request is unroutable", func() {
+		l.result = -1
+		req := &logcache_v1.AddToGroupRequest{
+			Name: "some-name-0",
+		}
+		_, err := r.AddToGroup(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 
 	It("proxies RemoveFromGroupRequests to the correct nodes", func() {
@@ -64,6 +75,15 @@ var _ = Describe("RPCReverseProxy", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("RemoveFromGroupRequests returns Unavailable when request is unroutable", func() {
+		l.result = -1
+		req := &logcache_v1.RemoveFromGroupRequest{
+			Name: "some-name-0",
+		}
+		_, err := r.RemoveFromGroup(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+	})
+
 	It("proxies ReadRequests to the correct nodes", func() {
 		l.result = 0
 		req := &logcache_v1.GroupReadRequest{
@@ -80,6 +100,15 @@ var _ = Describe("RPCReverseProxy", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("Read returns Unavailable when request is unroutable", func() {
+		l.result = -1
+		req := &logcache_v1.GroupReadRequest{
+			Name: "some-name-0",
+		}
+		_, err := r.Read(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
+	})
+
 	It("proxies GroupRequests to the correct nodes", func() {
 		l.result = 0
 		req := &logcache_v1.GroupRequest{
@@ -94,6 +123,15 @@ var _ = Describe("RPCReverseProxy", func() {
 		_, err = r.Group(context.Background(), req)
 		Expect(s2.groupRequests).To(ConsistOf(req))
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Group returns Unavailable when request is unroutable", func() {
+		l.result = -1
+		req := &logcache_v1.GroupRequest{
+			Name: "some-name-0",
+		}
+		_, err := r.Group(context.Background(), req)
+		Expect(grpc.Code(err)).To(Equal(codes.Unavailable))
 	})
 })
 

--- a/internal/routing/orchestrator.go
+++ b/internal/routing/orchestrator.go
@@ -1,0 +1,137 @@
+package routing
+
+import (
+	"context"
+	"sync"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+)
+
+// Orchestrator manages the Log Cache node's routes.
+type Orchestrator struct {
+	mu     sync.Mutex
+	ranges []rpc.Range
+
+	localAddr string
+	f         MetaFetcher
+	s         RangeSetter
+	hasher    func(string) uint64
+}
+
+// MetaFetcher returns meta for the local store.
+type MetaFetcher interface {
+	// Meta returns item that the node is responsible for.
+	Meta() []string
+}
+
+// MetaFetcherFunc transforms a function into a MetaFetcher.
+type MetaFetcherFunc func() []string
+
+// Meta implements MetaFetcher.
+func (f MetaFetcherFunc) Meta() []string {
+	return f()
+}
+
+type RangeSetter interface {
+	// SetRanges is used as a pass through for the orchestration service's
+	// SetRanges method.
+	SetRanges(ctx context.Context, in *rpc.SetRangesRequest) (*rpc.SetRangesResponse, error)
+}
+
+// NewOrchestrator returns a new Orchestrator.
+func NewOrchestrator(localAddr string, hasher func(string) uint64, f MetaFetcher, s RangeSetter) *Orchestrator {
+	return &Orchestrator{
+		localAddr: localAddr,
+		hasher:    hasher,
+		f:         f,
+		s:         s,
+	}
+}
+
+// AddRanges adds a range (from the scheduler) for data to be routed to.
+func (o *Orchestrator) AddRange(ctx context.Context, r *rpc.AddRangeRequest) (*rpc.AddRangeResponse, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.ranges = append(o.ranges, *r.Range)
+
+	return &rpc.AddRangeResponse{}, nil
+}
+
+// ListRanges returns all the ranges that are currently active. This includes
+// the ones with the latest term, and older ones that there is meta for.
+func (o *Orchestrator) ListRanges(ctx context.Context, r *rpc.ListRangesRequest) (*rpc.ListRangesResponse, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// Find latest term.
+	var latestTerm uint64
+	for _, r := range o.ranges {
+		if latestTerm < r.Term {
+			latestTerm = r.Term
+		}
+	}
+
+	// Separate old vs latest ranges.
+	var oldRanges []*rpc.Range
+	var ranges []*rpc.Range
+	for i := range o.ranges {
+		r := o.ranges[i]
+		if r.Term != latestTerm {
+			oldRanges = append(oldRanges, &r)
+			continue
+		}
+		ranges = append(ranges, &r)
+	}
+
+	// Keep latest ranges, and add back any old ones that have a hash
+	// associated with it that are not covered by a newer range.
+	for _, k := range o.f.Meta() {
+		h := o.hasher(k)
+
+		if o.findRange(h, ranges) >= 0 {
+			continue
+		}
+
+		// Not covered in newer range, try old range.
+		if i := o.findRange(h, oldRanges); i >= 0 {
+			ranges = append(ranges, oldRanges[i])
+		}
+	}
+
+	// Update results
+	o.ranges = nil
+	for _, r := range ranges {
+		o.ranges = append(o.ranges, *r)
+	}
+
+	return &rpc.ListRangesResponse{
+		Ranges: ranges,
+	}, nil
+}
+
+func (o *Orchestrator) findRange(h uint64, rs []*rpc.Range) int {
+	for i, r := range rs {
+		if h < r.Start || h > r.End {
+			// Outside of range
+			continue
+		}
+		return i
+	}
+
+	return -1
+}
+
+// SetRanges saves the ranges and passes them along to the RangeSetter.
+func (o *Orchestrator) SetRanges(ctx context.Context, in *rpc.SetRangesRequest) (*rpc.SetRangesResponse, error) {
+	if x, ok := in.Ranges[o.localAddr]; ok {
+		o.mu.Lock()
+		o.ranges = nil
+		for _, r := range x.Ranges {
+			o.ranges = append(o.ranges, *r)
+		}
+		o.mu.Unlock()
+	}
+
+	return o.s.SetRanges(ctx, in)
+}

--- a/internal/routing/orchestrator_test.go
+++ b/internal/routing/orchestrator_test.go
@@ -1,0 +1,203 @@
+package routing_test
+
+import (
+	"context"
+	"sync"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"code.cloudfoundry.org/log-cache/internal/routing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Orchestrator", func() {
+	var (
+		spyHasher      *spyHasher
+		spyMetaFetcher *spyMetaFetcher
+		spyRangeSetter *spyRangeSetter
+		o              *routing.Orchestrator
+	)
+
+	BeforeEach(func() {
+		spyHasher = newSpyHasher()
+		spyMetaFetcher = newSpyMetaFetcher()
+		spyRangeSetter = newSpyRangeSetter()
+		o = routing.NewOrchestrator("a", spyHasher.Hash, spyMetaFetcher, spyRangeSetter)
+	})
+
+	It("always keep the latest term", func() {
+		// SpyHasher returns 0 by default
+		spyMetaFetcher.results = []string{"a"}
+		o.AddRange(context.Background(), &rpc.AddRangeRequest{
+			Range: &rpc.Range{
+				Start: 0,
+				End:   1,
+				Term:  1,
+			},
+		})
+
+		o.AddRange(context.Background(), &rpc.AddRangeRequest{
+			Range: &rpc.Range{
+				Start: 0,
+				End:   1,
+				Term:  2,
+			},
+		})
+
+		o.AddRange(context.Background(), &rpc.AddRangeRequest{
+			Range: &rpc.Range{
+				Start: 1,
+				End:   2,
+				Term:  2,
+			},
+		})
+
+		resp, err := o.ListRanges(context.Background(), &rpc.ListRangesRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Ranges).To(ConsistOf([]*rpc.Range{
+			{
+				Start: 0,
+				End:   1,
+				Term:  2,
+			},
+			{
+				Start: 1,
+				End:   2,
+				Term:  2,
+			},
+		}))
+	})
+
+	It("keeps older terms with meta available", func() {
+		// SpyHasher returns 0 by default
+		spyMetaFetcher.results = []string{"a"}
+
+		o.AddRange(context.Background(), &rpc.AddRangeRequest{
+			Range: &rpc.Range{
+				Start: 0,
+				End:   1,
+				Term:  1,
+			},
+		})
+
+		o.AddRange(context.Background(), &rpc.AddRangeRequest{
+			Range: &rpc.Range{
+				Start: 1,
+				End:   2,
+				Term:  2,
+			},
+		})
+
+		resp, err := o.ListRanges(context.Background(), &rpc.ListRangesRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Ranges).To(ConsistOf([]*rpc.Range{
+			{
+				Start: 0,
+				End:   1,
+				Term:  1,
+			},
+			{
+				Start: 1,
+				End:   2,
+				Term:  2,
+			},
+		}))
+	})
+
+	It("survives race the detector", func() {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func(o *routing.Orchestrator) {
+			wg.Done()
+			for i := 0; i < 100; i++ {
+				o.ListRanges(context.Background(), &rpc.ListRangesRequest{})
+			}
+		}(o)
+		wg.Wait()
+
+		for i := 0; i < 100; i++ {
+			o.AddRange(context.Background(), &rpc.AddRangeRequest{
+				Range: &rpc.Range{
+					Start: 1,
+					End:   2,
+					Term:  2,
+				},
+			})
+		}
+	})
+
+	It("passes through SetRanges requests and keeps track of the latest ranges", func() {
+		expected := &rpc.SetRangesRequest{
+			Ranges: map[string]*rpc.Ranges{
+				"a": &rpc.Ranges{
+					Ranges: []*rpc.Range{
+						{
+							Term: 1,
+						},
+					},
+				},
+			},
+		}
+		o.SetRanges(context.Background(), expected)
+		resp, err := o.ListRanges(context.Background(), &rpc.ListRangesRequest{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(spyRangeSetter.requests).To(ConsistOf(expected))
+		Expect(resp.Ranges).To(ConsistOf(&rpc.Range{
+			Term: 1,
+		}))
+	})
+})
+
+type spyMetaFetcher struct {
+	results []string
+}
+
+func newSpyMetaFetcher() *spyMetaFetcher {
+	return &spyMetaFetcher{}
+}
+
+func (s *spyMetaFetcher) Meta() []string {
+	return s.results
+}
+
+type spyHasher struct {
+	mu      sync.Mutex
+	ids     []string
+	results []uint64
+}
+
+func newSpyHasher() *spyHasher {
+	return &spyHasher{}
+}
+
+func (s *spyHasher) Hash(id string) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ids = append(s.ids, id)
+
+	if len(s.results) == 0 {
+		return 0
+	}
+
+	r := s.results[0]
+	s.results = s.results[1:]
+	return r
+}
+
+type spyRangeSetter struct {
+	mu       sync.Mutex
+	requests []*rpc.SetRangesRequest
+}
+
+func newSpyRangeSetter() *spyRangeSetter {
+	return &spyRangeSetter{}
+}
+
+func (s *spyRangeSetter) SetRanges(ctx context.Context, in *rpc.SetRangesRequest) (*rpc.SetRangesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests = append(s.requests, in)
+	return &rpc.SetRangesResponse{}, nil
+}

--- a/internal/routing/routing_table.go
+++ b/internal/routing/routing_table.go
@@ -1,0 +1,156 @@
+package routing
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"github.com/emirpasic/gods/trees/avltree"
+	"github.com/emirpasic/gods/utils"
+)
+
+// RoutingTable makes decisions for where a item should be routed.
+type RoutingTable struct {
+	mu    sync.RWMutex
+	addrs map[string]int
+	h     func(string) uint64
+
+	table    []rangeInfo
+	avlTable *avltree.Tree
+}
+
+// NewRoutingTable returns a new RoutingTable.
+func NewRoutingTable(addrs []string, hasher func(string) uint64) *RoutingTable {
+	a := make(map[string]int)
+	for i, addr := range addrs {
+		a[addr] = i
+	}
+
+	return &RoutingTable{
+		addrs:    a,
+		h:        hasher,
+		avlTable: avltree.NewWith(utils.UInt64Comparator),
+	}
+}
+
+// Lookup takes a item, hash it and determine what node it should be
+// routed to.
+func (t *RoutingTable) Lookup(item string) int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lookup(t.h(item), t.avlTable.Root)
+}
+
+func (t *RoutingTable) lookup(hash uint64, n *avltree.Node) int {
+	if n == nil {
+		return -1
+	}
+
+	r := n.Value.(rangeInfo)
+	if hash < r.r.Start {
+		return t.lookup(hash, n.Children[0])
+	}
+
+	if hash > r.r.End {
+		return t.lookup(hash, n.Children[1])
+	}
+
+	if hash > r.r.Start && hash <= r.r.End {
+		return r.idx
+	}
+
+	return -1
+}
+
+// LookupAll returns every index that has a range where the item would
+// fall under.
+func (t *RoutingTable) LookupAll(item string) []int {
+	h := t.h(item)
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var result []int
+	ranges := t.table
+
+	for {
+		i := t.findRange(h, ranges)
+		if i < 0 {
+			break
+		}
+		result = append(result, ranges[i].idx)
+		ranges = ranges[i+1:]
+	}
+
+	return result
+}
+
+// SetRanges sets the routing table.
+func (t *RoutingTable) SetRanges(ctx context.Context, in *rpc.SetRangesRequest) (*rpc.SetRangesResponse, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.table = nil
+	var latestTerm uint64
+	for addr, ranges := range in.Ranges {
+		for _, r := range ranges.Ranges {
+			t.table = append(t.table, rangeInfo{
+				idx: t.addrs[addr],
+				r:   *r,
+			})
+
+			if latestTerm < r.Term {
+				latestTerm = r.Term
+			}
+		}
+	}
+
+	sort.Sort(rangeInfos(t.table))
+
+	t.avlTable = avltree.NewWith(utils.UInt64Comparator)
+	for _, r := range t.table {
+		if r.r.Term == latestTerm {
+			t.avlTable.Put(r.r.Start, r)
+		}
+	}
+
+	return &rpc.SetRangesResponse{}, nil
+}
+
+func (t *RoutingTable) findRange(h uint64, rs []rangeInfo) int {
+	for i, r := range rs {
+		if h < r.r.Start || h > r.r.End {
+			// Outside of range
+			continue
+		}
+		return i
+	}
+
+	return -1
+}
+
+type rangeInfo struct {
+	r   rpc.Range
+	idx int
+}
+
+type rangeInfos []rangeInfo
+
+func (r rangeInfos) Len() int {
+	return len(r)
+}
+
+func (r rangeInfos) Less(i, j int) bool {
+	if r[i].r.Start == r[j].r.Start {
+		return r[i].r.Term > r[j].r.Term
+	}
+
+	return r[i].r.Start < r[j].r.Start
+}
+
+func (r rangeInfos) Swap(i, j int) {
+	tmp := r[i]
+	r[i] = r[j]
+	r[j] = tmp
+}

--- a/internal/routing/routing_table_test.go
+++ b/internal/routing/routing_table_test.go
@@ -18,7 +18,7 @@ var _ = Describe("RoutingTable", func() {
 
 	BeforeEach(func() {
 		spyHasher = newSpyHasher()
-		r = routing.NewRoutingTable([]string{"a", "b", "c"}, spyHasher.Hash)
+		r = routing.NewRoutingTable([]string{"a", "b", "c", "d"}, spyHasher.Hash)
 	})
 
 	It("returns the correct index for the node", func() {
@@ -42,6 +42,11 @@ var _ = Describe("RoutingTable", func() {
 						{Start: 201, End: 300, Term: 1},
 					},
 				},
+				"d": {
+					Ranges: []*rpc.Range{
+						{Start: 101, End: 200, Term: 1},
+					},
+				},
 			},
 		})
 
@@ -49,7 +54,7 @@ var _ = Describe("RoutingTable", func() {
 
 		i := r.Lookup("some-id")
 		Expect(spyHasher.ids).To(ConsistOf("some-id"))
-		Expect(i).To(Equal(1))
+		Expect(i).To(Equal([]int{3, 1}))
 	})
 
 	It("returns the correct index for the node", func() {
@@ -78,12 +83,12 @@ var _ = Describe("RoutingTable", func() {
 
 		i := r.LookupAll("some-id")
 		Expect(spyHasher.ids).To(ConsistOf("some-id"))
-		Expect(i).To(ConsistOf(0, 1))
+		Expect(i).To(Equal([]int{1, 0}))
 	})
 
-	It("returns -1 for a non-routable hash", func() {
+	It("returns an empty slice for a non-routable hash", func() {
 		i := r.Lookup("some-id")
-		Expect(i).To(Equal(-1))
+		Expect(i).To(BeEmpty())
 	})
 
 	It("survives the race detector", func() {

--- a/internal/routing/routing_table_test.go
+++ b/internal/routing/routing_table_test.go
@@ -1,0 +1,106 @@
+package routing_test
+
+import (
+	"context"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"code.cloudfoundry.org/log-cache/internal/routing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RoutingTable", func() {
+	var (
+		spyHasher *spyHasher
+		r         *routing.RoutingTable
+	)
+
+	BeforeEach(func() {
+		spyHasher = newSpyHasher()
+		r = routing.NewRoutingTable([]string{"a", "b", "c"}, spyHasher.Hash)
+	})
+
+	It("returns the correct index for the node", func() {
+		r.SetRanges(context.Background(), &rpc.SetRangesRequest{
+			map[string]*rpc.Ranges{
+				"a": {
+					Ranges: []*rpc.Range{
+						{Start: 0, End: 100, Term: 1},
+
+						// Older term should and be ignored
+						{Start: 101, End: 200, Term: 0},
+					},
+				},
+				"b": {
+					Ranges: []*rpc.Range{
+						{Start: 101, End: 200, Term: 1},
+					},
+				},
+				"c": {
+					Ranges: []*rpc.Range{
+						{Start: 201, End: 300, Term: 1},
+					},
+				},
+			},
+		})
+
+		spyHasher.results = []uint64{200}
+
+		i := r.Lookup("some-id")
+		Expect(spyHasher.ids).To(ConsistOf("some-id"))
+		Expect(i).To(Equal(1))
+	})
+
+	It("returns the correct index for the node", func() {
+		r.SetRanges(context.Background(), &rpc.SetRangesRequest{
+			map[string]*rpc.Ranges{
+				"a": {
+					Ranges: []*rpc.Range{
+						{Start: 0, End: 100, Term: 1},
+						{Start: 101, End: 200, Term: 0},
+					},
+				},
+				"b": {
+					Ranges: []*rpc.Range{
+						{Start: 101, End: 200, Term: 1},
+					},
+				},
+				"c": {
+					Ranges: []*rpc.Range{
+						{Start: 201, End: 300, Term: 1},
+					},
+				},
+			},
+		})
+
+		spyHasher.results = []uint64{200}
+
+		i := r.LookupAll("some-id")
+		Expect(spyHasher.ids).To(ConsistOf("some-id"))
+		Expect(i).To(ConsistOf(0, 1))
+	})
+
+	It("returns -1 for a non-routable hash", func() {
+		i := r.Lookup("some-id")
+		Expect(i).To(Equal(-1))
+	})
+
+	It("survives the race detector", func() {
+		go func() {
+			for i := 0; i < 100; i++ {
+				r.Lookup("a")
+			}
+		}()
+
+		go func() {
+			for i := 0; i < 100; i++ {
+				r.LookupAll("a")
+			}
+		}()
+
+		for i := 0; i < 100; i++ {
+			r.SetRanges(context.Background(), &rpc.SetRangesRequest{})
+		}
+	})
+})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -137,8 +137,11 @@ func (s *Store) Put(e *loggregator_v2.Envelope, index string) {
 	if e.Timestamp > m.Newest.UnixNano() {
 		m.Newest = time.Unix(0, e.Timestamp)
 	}
-	m.Oldest = time.Unix(0, t.Left().Key.(int64))
-	s.meta[index] = m
+
+	if t.Size() > 0 {
+		m.Oldest = time.Unix(0, t.Left().Key.(int64))
+		s.meta[index] = m
+	}
 }
 
 // truncate removes the oldest envelope from the entire cache. It considers

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -278,6 +278,17 @@ var _ = Describe("Store", func() {
 			Newest:  time.Unix(0, 4),
 		}))
 	})
+
+	It("survives the just added entry from being pruned", func() {
+		s = store.NewStore(2, 2, sp, sm)
+
+		s.Put(buildTypedEnvelope(0, "index-0", &loggregator_v2.Log{}), "index-0")
+		s.Put(buildTypedEnvelope(1, "index-0", &loggregator_v2.Log{}), "index-0")
+
+		sp.result = 1
+		s.Put(buildTypedEnvelope(-1, "index-1", &loggregator_v2.Log{}), "index-1")
+		Expect(s.Meta()).ToNot(HaveKey("index-1"))
+	})
 })
 
 func buildEnvelope(timestamp int64, sourceID string) *loggregator_v2.Envelope {

--- a/scheduler.go
+++ b/scheduler.go
@@ -1,0 +1,221 @@
+package logcache
+
+import (
+	"io/ioutil"
+	"log"
+	"sync"
+	"time"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	orchestrator "code.cloudfoundry.org/go-orchestrator"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// Scheduler manages the routes of the Log Cache nodes.
+type Scheduler struct {
+	log      *log.Logger
+	metrics  Metrics
+	interval time.Duration
+	count    int
+	orch     *orchestrator.Orchestrator
+	dialOpts []grpc.DialOption
+
+	clients []clientInfo
+}
+
+// NewScheduler returns a new Scheduler. Addrs are the addresses of the Cache
+// nodes.
+func NewScheduler(addrs []string, opts ...SchedulerOption) *Scheduler {
+	s := &Scheduler{
+		log:      log.New(ioutil.Discard, "", 0),
+		metrics:  nopMetrics{},
+		interval: time.Minute,
+		count:    100,
+		orch:     orchestrator.New(&comm{}),
+		dialOpts: []grpc.DialOption{grpc.WithInsecure()},
+	}
+
+	for _, o := range opts {
+		o(s)
+	}
+
+	for _, addr := range addrs {
+		conn, err := grpc.Dial(addr, s.dialOpts...)
+		if err != nil {
+			s.log.Panic(err)
+		}
+		s.clients = append(s.clients, clientInfo{l: rpc.NewOrchestrationClient(conn), addr: addr})
+	}
+
+	return s
+}
+
+// SchedulerOption configures a Scheduler.
+type SchedulerOption func(*Scheduler)
+
+// WithSchedulerLogger returns a SchedulerOption that configures the logger
+// used for the Scheduler. Defaults to silent logger.
+func WithSchedulerLogger(l *log.Logger) SchedulerOption {
+	return func(s *Scheduler) {
+		s.log = l
+	}
+}
+
+// WithSchedulerMetrics returns a SchedulerOption that configures the metrics
+// for the Scheduler. It will add metrics to the given map.
+func WithSchedulerMetrics(m Metrics) SchedulerOption {
+	return func(s *Scheduler) {
+		s.metrics = m
+	}
+}
+
+// WithSchedulerInterval returns a SchedulerOption that configures the
+// interval for terms to take place. It defaults to a minute.
+func WithSchedulerInterval(interval time.Duration) SchedulerOption {
+	return func(s *Scheduler) {
+		s.interval = interval
+	}
+}
+
+// WithSchedulerCount returns a SchedulerOption that configures the
+// number of ranges to manage. Defaults to 100.
+func WithSchedulerCount(count int) SchedulerOption {
+	return func(s *Scheduler) {
+		s.count = count
+	}
+}
+
+// WithSchedulerDialOpts are the gRPC options used to dial peer Log Cache
+// nodes. It defaults to WithInsecure().
+func WithSchedulerDialOpts(opts ...grpc.DialOption) SchedulerOption {
+	return func(s *Scheduler) {
+		s.dialOpts = opts
+	}
+}
+
+// Start starts the scheduler. It does not block.
+func (s *Scheduler) Start() {
+	for _, lc := range s.clients {
+		s.orch.AddWorker(lc)
+	}
+
+	maxHash := uint64(18446744073709551615)
+	x := maxHash / uint64(s.count)
+	var start uint64
+
+	for i := 0; i < s.count-1; i++ {
+		s.orch.AddTask(rpc.Range{
+			Start: start,
+			End:   start + x,
+		})
+		start += x + 1
+	}
+
+	s.orch.AddTask(rpc.Range{
+		Start: start,
+		End:   maxHash,
+	})
+
+	go func() {
+		for range time.Tick(s.interval) {
+			// Apply changes
+			s.orch.NextTerm(context.Background())
+
+			// Run again before setting remote tables to allow the
+			// orchestrator to go and query for updates.
+			s.orch.NextTerm(context.Background())
+			s.setRemoteTables(s.convertWorkerState(s.orch.LastActual()))
+		}
+	}()
+}
+
+func (s *Scheduler) setRemoteTables(m map[string]*rpc.Ranges) {
+	req := &rpc.SetRangesRequest{
+		Ranges: m,
+	}
+
+	for _, lc := range s.clients {
+		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		if _, err := lc.l.SetRanges(ctx, req); err != nil {
+			s.log.Printf("failed to set remote table: %s", err)
+			continue
+		}
+	}
+}
+
+func (s *Scheduler) convertWorkerState(ws []orchestrator.WorkerState) map[string]*rpc.Ranges {
+	m := make(map[string]*rpc.Ranges)
+	for _, w := range ws {
+		var ranges []*rpc.Range
+		for _, t := range w.Tasks {
+			rr := t.(rpc.Range)
+			ranges = append(ranges, &rr)
+		}
+
+		m[w.Name.(clientInfo).addr] = &rpc.Ranges{
+			Ranges: ranges,
+		}
+	}
+
+	return m
+}
+
+type clientInfo struct {
+	l    rpc.OrchestrationClient
+	addr string
+}
+
+type comm struct {
+	mu   sync.Mutex
+	term uint64
+}
+
+// List implements orchestrator.Communicator.
+func (c *comm) List(ctx context.Context, worker interface{}) ([]interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lc := worker.(clientInfo)
+
+	resp, err := lc.l.ListRanges(ctx, &rpc.ListRangesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	var results []interface{}
+	for _, r := range resp.Ranges {
+		if c.term <= r.Term {
+			c.term = r.Term + 1
+		}
+
+		// The orch algorithm only knows about term 0, therefore we need to
+		// ditch the term value.
+		r.Term = 0
+		results = append(results, *r)
+	}
+
+	return results, nil
+}
+
+// Add implements orchestrator.Communicator.
+func (c *comm) Add(ctx context.Context, worker interface{}, task interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lc := worker.(clientInfo)
+	r := task.(rpc.Range)
+	r.Term = c.term
+
+	_, err := lc.l.AddRange(ctx, &rpc.AddRangeRequest{
+		Range: &r,
+	})
+
+	return err
+}
+
+// Remvoe implements orchestrator.Communicator.
+func (c *comm) Remove(ctx context.Context, worker interface{}, task interface{}) error {
+	// NOP
+	return nil
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,0 +1,183 @@
+package logcache_test
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	rpc "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"code.cloudfoundry.org/log-cache"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+var _ = Describe("Scheduler", func() {
+	var (
+		s *logcache.Scheduler
+
+		spy1 *spyOrchestration
+		spy2 *spyOrchestration
+	)
+
+	BeforeEach(func() {
+		spy1 = startSpyOrchestration()
+		spy2 = startSpyOrchestration()
+
+		s = logcache.NewScheduler(
+			[]string{
+				spy1.lis.Addr().String(),
+				spy2.lis.Addr().String(),
+			},
+			logcache.WithSchedulerInterval(time.Millisecond),
+			logcache.WithSchedulerCount(7),
+		)
+
+	})
+
+	It("schedules the ranges evenly across the nodes", func() {
+		s.Start()
+		Eventually(spy1.ReqCount).Should(BeNumerically(">=", 50))
+		Eventually(spy2.ReqCount).Should(BeNumerically(">=", 50))
+
+		reqs := append(spy1.AddReqs(), spy2.AddReqs()...)
+
+		count := 7
+
+		maxHash := uint64(18446744073709551615)
+		x := maxHash / uint64(count)
+		var start uint64
+
+		for i := 0; i < count; i++ {
+			if i == count-1 {
+				Expect(reqs).To(ContainElement(&rpc.Range{
+					Start: start,
+					End:   maxHash,
+				}))
+				break
+			}
+			Expect(reqs).To(ContainElement(&rpc.Range{
+				Start: start,
+				End:   start + x,
+			}))
+
+			start += x + 1
+		}
+	})
+
+	It("reads the term from the cluster to set the next term", func() {
+		spy1.listRanges = []*rpc.Range{
+			{
+				Term: 99,
+			},
+		}
+
+		spy2.listRanges = []*rpc.Range{
+			{
+				Term: 100,
+			},
+		}
+
+		s.Start()
+
+		Eventually(spy1.ReqCount).ShouldNot(BeZero())
+		Expect(spy1.AddReqs()[0].Term).To(Equal(uint64(101)))
+	})
+
+	It("sets the range table after listing all the nodes", func() {
+		s.Start()
+
+		Eventually(spy1.SetCount).ShouldNot(BeZero())
+		Eventually(spy2.SetCount).ShouldNot(BeZero())
+
+		Expect(spy1.SetReqs()[0].Ranges).To(HaveLen(2))
+		Expect(spy2.SetReqs()[0].Ranges).To(HaveLen(2))
+	})
+})
+
+type spyOrchestration struct {
+	mu      sync.Mutex
+	lis     net.Listener
+	addReqs []*rpc.Range
+	addErr  error
+
+	listReqs   []*rpc.ListRangesRequest
+	listRanges []*rpc.Range
+	listErr    error
+
+	setReqs []*rpc.SetRangesRequest
+}
+
+func startSpyOrchestration() *spyOrchestration {
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+
+	s := &spyOrchestration{
+		lis: lis,
+	}
+
+	go func() {
+		srv := grpc.NewServer()
+		rpc.RegisterOrchestrationServer(srv, s)
+		if err := srv.Serve(lis); err != nil {
+			panic(err)
+		}
+	}()
+
+	return s
+}
+
+func (s *spyOrchestration) AddRange(ctx context.Context, r *rpc.AddRangeRequest) (*rpc.AddRangeResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.addReqs = append(s.addReqs, r.Range)
+	return &rpc.AddRangeResponse{}, s.addErr
+}
+
+func (s *spyOrchestration) AddReqs() []*rpc.Range {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	addReqs := make([]*rpc.Range, len(s.addReqs))
+	copy(addReqs, s.addReqs)
+	return addReqs
+}
+
+func (s *spyOrchestration) ReqCount() int {
+	return len(s.AddReqs())
+}
+
+func (s *spyOrchestration) ListRanges(ctx context.Context, r *rpc.ListRangesRequest) (*rpc.ListRangesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.listReqs = append(s.listReqs, r)
+	return &rpc.ListRangesResponse{
+		Ranges: s.listRanges,
+	}, s.listErr
+}
+
+func (s *spyOrchestration) SetRanges(ctx context.Context, r *rpc.SetRangesRequest) (*rpc.SetRangesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.setReqs = append(s.setReqs, r)
+	return &rpc.SetRangesResponse{}, nil
+}
+
+func (s *spyOrchestration) SetReqs() []*rpc.SetRangesRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	setReqs := make([]*rpc.SetRangesRequest, len(s.setReqs))
+	copy(setReqs, s.setReqs)
+	return setReqs
+}
+
+func (s *spyOrchestration) SetCount() int {
+	return len(s.SetReqs())
+}


### PR DESCRIPTION
These commits add a scheduler (for groups only) that help spread the load across the nodes.

Related Log-Cache-Release [PR](https://github.com/cloudfoundry-incubator/log-cache-release/pull/10)