### PR TITLE
Adds 'args' to shard group output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ curl "http://<log-cache-addr>:8080/v1/shard_group/<group-name>/?start_time=<star
 ##### Response Body
 ```
 {
-  "envelopes": {"batch": [...] }
+  "envelopes": {"batch": [...] },
+  "args": [...]
 }
 ```
 
@@ -125,7 +126,10 @@ not exist, then it gets created. Each shard-group may contain many sub-groups.
 Each sub-group may contain many source-ids. Each requester (identified by a
 `requester_id`) will receive an equal subset of the shard group. A sub-group
 ensures that each requester receives envelopes for the given source-ids
-grouped together (and not spread across other requesters).
+grouped together (and not spread across other requesters). When setting a
+shard-group, an `arg` can also be provided. This arg will be returned when
+reading back from the group. This gives context as to what data has been
+read.
 
 ##### Request Body
 
@@ -134,7 +138,8 @@ grouped together (and not spread across other requesters).
   "sourceIds": [
     "source-id-1",
     "source-id-2"
-  ]
+  ],
+  "arg": "some-arg"
 }
 ```
 
@@ -158,7 +163,9 @@ curl "http://<log-cache-addr>:8080/v1/shard_group/<group-name>/meta"
 ##### Response Body
 ```
 {
-  "source_ids": [...]
+  "source_ids": [...],
+  "requester_ids": [...],
+  "args": [...]
 }
 ```
 

--- a/api/v1/shard_group_reader.proto
+++ b/api/v1/shard_group_reader.proto
@@ -40,6 +40,10 @@ message SetShardGroupRequest {
 
 message GroupedSourceIds {
     repeated string source_ids = 1;
+
+    // arg are given back to the requester when they recieve the given
+    // sub_group.
+    string arg = 2;
 }
 
 message SetShardGroupResponse {
@@ -60,6 +64,10 @@ message ShardGroupReadRequest {
 
 message ShardGroupReadResponse {
     loggregator.v2.EnvelopeBatch envelopes = 1;
+
+    // args are given back to the requester when they recieve the given
+    // sub_group.
+    repeated string args = 2;
 }
 
 message ShardGroupRequest {
@@ -72,5 +80,6 @@ message ShardGroupRequest {
 message ShardGroupResponse {
     repeated GroupedSourceIds sub_groups = 1;
     repeated uint64 requester_ids = 2;
+    repeated string args = 3;
 }
 


### PR DESCRIPTION
The arg is given with the sub-group. It gives
context to what is returned with each read to
a group.

resolves #55

[#157270539]