### PR TITLE
Ensure the timestamps that are returned correspond to the requested range

### DIFF
--- a/internal/promql/promql.go
+++ b/internal/promql/promql.go
@@ -344,6 +344,11 @@ func (l *LogCacheQuerier) Select(params *storage.SelectParams, ll ...*labels.Mat
 		SourceId:  sourceID,
 		StartTime: l.start.Add(-time.Second).UnixNano(),
 		EndTime:   l.end.UnixNano(),
+		EnvelopeTypes: []logcache_v1.EnvelopeType{
+			logcache_v1.EnvelopeType_GAUGE,
+			logcache_v1.EnvelopeType_COUNTER,
+			logcache_v1.EnvelopeType_TIMER,
+		},
 	})
 	if err != nil {
 		l.errf(err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -130,7 +130,8 @@ func (storage *storage) insertOrSwap(store *Store, e *loggregator_v2.Envelope) {
 		}
 	}
 
-	storage.Put(e.Timestamp+timestampFudge, e)
+	e.Timestamp += timestampFudge
+	storage.Put(e.Timestamp, e)
 
 	if e.Timestamp > storage.meta.NewestTimestamp {
 		storage.meta.NewestTimestamp = e.Timestamp

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -221,8 +221,8 @@ var _ = Describe("Store", func() {
 		envelopes := s.Get("a", start, end, nil, 10, false)
 		Expect(envelopes).To(HaveLen(5))
 
-		for _, e := range envelopes {
-			Expect(e.Timestamp).To(Equal(int64(3)))
+		for i, e := range envelopes {
+			Expect(e.Timestamp).To(Equal(int64(3 + i)))
 		}
 
 		Expect(sm.GetValue("Expired")).To(Equal(3.0))


### PR DESCRIPTION
Also, only request GAUGE, COUNTER and TIMER types for PromQL requests.