### PR TITLE
Fix handling of 'Bearer' prefix in Authorization header.

### DIFF
--- a/internal/auth/uaa_client.go
+++ b/internal/auth/uaa_client.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -111,8 +112,10 @@ func (c *UAAClient) Read(token string) (Oauth2ClientContext, error) {
 	}, nil
 }
 
+var bearerRE = regexp.MustCompile(`(?i)^bearer\s+`)
+
 func trimBearer(authToken string) string {
-	return strings.TrimSpace(strings.TrimPrefix(authToken, "bearer"))
+	return bearerRE.ReplaceAllString(authToken, "")
 }
 
 type uaaResponse struct {


### PR DESCRIPTION
According to the RFC[1] the bearer prefix has a capital 'B'. The
trimBearer function was only stripping the prefix when it had a
lowercase 'b' meaning that requests using an Authorization header with
an RFC compliant 'Bearer' prefix would fail.

This updates the trimBearer function to remove the bearer prefix in a
case-insensitive manner. I chose to do this instead of merely correcting
to to trim 'Bearer' in order to retain backwards compatability.

[1]https://tools.ietf.org/html/rfc6750#section-2.1