### PR TITLE
Extend CAPI client pagination fix to all requests.

### DIFF
--- a/internal/auth/capi_client.go
+++ b/internal/auth/capi_client.go
@@ -109,7 +109,6 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		return nil
 	}
 
-	preserveScheme, preserveHost := req.URL.Scheme, req.URL.Host
 	for {
 		resources, nextPageURL, err := c.doResourceRequest(req, authToken, c.storeAppsLatency)
 		if err != nil {
@@ -126,7 +125,6 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		}
 
 		req.URL = nextPageURL
-		req.URL.Scheme, req.URL.Host = preserveScheme, preserveHost
 	}
 
 	req, err = http.NewRequest(http.MethodGet, c.externalCapi+"/v3/service_instances", nil)
@@ -237,6 +235,7 @@ func (c *CAPIClient) doResourceRequest(req *http.Request, authToken string, metr
 		if err != nil {
 			return apps.Resources, nextPageURL, fmt.Errorf("failed to parse URL %s: %s", apps.Pagination.Next.Href, err)
 		}
+		nextPageURL.Scheme, nextPageURL.Host = req.URL.Scheme, req.URL.Host
 	}
 
 	return apps.Resources, nextPageURL, nil

--- a/internal/auth/capi_client_test.go
+++ b/internal/auth/capi_client_test.go
@@ -72,7 +72,6 @@ var _ = Describe("CAPIClient", func() {
 			By("continuing to call until the previously cached response expires")
 			Eventually(func() int {
 				authorized = tc.client.IsAuthorized("37cbff06-79ef-4146-a7b0-01838940f185", "some-token")
-
 				Expect(authorized).To(BeTrue())
 
 				return len(tc.capiClient.requests)
@@ -186,7 +185,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://internal.capi.com/v3/service_instances?page=2&per_page=2"
+                      "href": "https://external.capi.com/v3/service_instances?page=2&per_page=2"
                     }
                   },
                   "resources": [
@@ -203,9 +202,7 @@ var _ = Describe("CAPIClient", func() {
 			sourceIDs := tc.client.AvailableSourceIDs("some-token")
 			Expect(tc.capiClient.requests).To(HaveLen(3))
 			secondPageReq := tc.capiClient.requests[2]
-			Expect(secondPageReq.URL.Path).To(Equal("/v3/service_instances"))
-			Expect(secondPageReq.URL.Query().Get("page")).To(Equal("2"))
-			Expect(secondPageReq.URL.Query().Get("per_page")).To(Equal("2"))
+			Expect(secondPageReq.URL.String()).To(Equal("http://internal.capi.com/v3/service_instances?page=2&per_page=2"))
 
 			Expect(sourceIDs).To(ConsistOf("service-1", "service-2", "service-3"))
 		})
@@ -327,7 +324,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://internal.capi.com/v3/apps?page=2&per_page=2"
+                      "href": "https://external.capi.com/v3/apps?page=2&per_page=2"
                     }
                   },
                   "resources": [
@@ -346,9 +343,7 @@ var _ = Describe("CAPIClient", func() {
 
 			Expect(tc.capiClient.requests).To(HaveLen(2))
 			secondPageReq := tc.capiClient.requests[1]
-			Expect(secondPageReq.URL.Path).To(Equal("/v3/apps"))
-			Expect(secondPageReq.URL.Query().Get("page")).To(Equal("2"))
-			Expect(secondPageReq.URL.Query().Get("per_page")).To(Equal("2"))
+			Expect(secondPageReq.URL.String()).To(Equal("http://internal.capi.com/v3/apps?page=2&per_page=2"))
 			Expect(sourceIds).To(HaveKeyWithValue("app-name", ConsistOf("app-0", "app-1", "app-2")))
 		})
 

--- a/internal/auth/capi_client_test.go
+++ b/internal/auth/capi_client_test.go
@@ -27,7 +27,7 @@ var _ = Describe("CAPIClient", func() {
 		capiClient := newSpyHTTPClient()
 		metrics := newSpyMetrics()
 		client := auth.NewCAPIClient(
-			"http://external.capi.com",
+			"http://internal.capi.com",
 			capiClient,
 			metrics,
 			log.New(ioutil.Discard, "", 0),
@@ -138,12 +138,12 @@ var _ = Describe("CAPIClient", func() {
 
 			appsReq := tc.capiClient.requests[0]
 			Expect(appsReq.Method).To(Equal(http.MethodGet))
-			Expect(appsReq.URL.String()).To(Equal("http://external.capi.com/v3/apps"))
+			Expect(appsReq.URL.String()).To(Equal("http://internal.capi.com/v3/apps"))
 			Expect(appsReq.Header.Get("Authorization")).To(Equal("some-token"))
 
 			servicesReq := tc.capiClient.requests[1]
 			Expect(servicesReq.Method).To(Equal(http.MethodGet))
-			Expect(servicesReq.URL.String()).To(Equal("http://external.capi.com/v3/service_instances"))
+			Expect(servicesReq.URL.String()).To(Equal("http://internal.capi.com/v3/service_instances"))
 			Expect(servicesReq.Header.Get("Authorization")).To(Equal("some-token"))
 		})
 
@@ -155,7 +155,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://thisismycapi.com/v3/apps?page=2&per_page=1"
+                      "href": "https://external.capi.com/v3/apps?page=2&per_page=1"
                     }
                   },
                   "resources": [
@@ -174,7 +174,7 @@ var _ = Describe("CAPIClient", func() {
 			Expect(tc.capiClient.requests).To(HaveLen(3))
 			secondPageReq := tc.capiClient.requests[1]
 
-			Expect(secondPageReq.URL.String()).To(Equal("http://external.capi.com/v3/apps?page=2&per_page=1"))
+			Expect(secondPageReq.URL.String()).To(Equal("http://internal.capi.com/v3/apps?page=2&per_page=1"))
 			Expect(sourceIDs).To(ConsistOf("app-1", "app-2"))
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://external.capi.com/v3/service_instances?page=2&per_page=2"
+                      "href": "https://internal.capi.com/v3/service_instances?page=2&per_page=2"
                     }
                   },
                   "resources": [
@@ -296,7 +296,7 @@ var _ = Describe("CAPIClient", func() {
 
 			appsReq := tc.capiClient.requests[0]
 			Expect(appsReq.Method).To(Equal(http.MethodGet))
-			Expect(appsReq.URL.Host).To(Equal("external.capi.com"))
+			Expect(appsReq.URL.Host).To(Equal("internal.capi.com"))
 			Expect(appsReq.URL.Path).To(Equal("/v3/apps"))
 			Expect(appsReq.URL.Query().Get("names")).To(Equal("app-name-1,app-name-2"))
 			// Expect(appsReq.URL.Query().Get("per_page")).To(Equal("5000"))
@@ -327,7 +327,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://external.capi.com/v3/apps?page=2&per_page=2"
+                      "href": "https://internal.capi.com/v3/apps?page=2&per_page=2"
                     }
                   },
                   "resources": [


### PR DESCRIPTION
In 1c3fd13 a fix was made to the /v3/apps request in AvailableSourceIDs
to ensure it continues to use the original endpoint when iterating
through pages of responses.

The same fix is also needed for the service instances request, and also
in the GetRelatedSourceIds method. This therefore moves the fix into the
doResourceRequest method so that it applies to all requests.

I've also taken the opportunity to extract the pagination logic into a
`doPaginatedResourceRequest` method to avoid the repetition.