### PR TITLE
add grpc keep alive params for nozzle

### DIFF
--- a/cmd/nozzle/main.go
+++ b/cmd/nozzle/main.go
@@ -6,11 +6,13 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	envstruct "code.cloudfoundry.org/go-envstruct"
 	"code.cloudfoundry.org/log-cache/internal/metrics"
 	. "code.cloudfoundry.org/log-cache/internal/nozzle"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	loggregator "code.cloudfoundry.org/go-loggregator"
 )
@@ -50,6 +52,11 @@ func main() {
 			loggr.Printf("dropped %d envelope batches", missed)
 			dropped(uint64(missed))
 		}),
+		loggregator.WithEnvelopeStreamConnectorDialOptions(grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             30 * time.Second,
+			PermitWithoutStream: true,
+		})),
 	)
 
 	nozzle := NewNozzle(


### PR DESCRIPTION
If RLP suddenly crashed without gracefully close all the grpc connections, the grpc connection of current nozzle without keep alive parameters will hold there and no envelope can be stream.